### PR TITLE
fix[busybox] add necessary quote for busybox_testcode.sh

### DIFF
--- a/scripts/busybox/busybox_testcode.sh
+++ b/scripts/busybox/busybox_testcode.sh
@@ -15,7 +15,7 @@
 do
 	eval "./busybox $line"
 	RTN=$?
-	if [[ $RTN -ne 0 && $line != "false" ]] ;then
+	if [[ $RTN -ne 0 && "$line" != "false" ]] ;then
 		echo "testcase busybox $line fail"
 		# echo "return: $RTN, cmd: $line" >> $RST
 	else


### PR DESCRIPTION
without this modification, busybox will complain if the $line contains  spaces