### PR TITLE
修正了busybox_cmd.txt中不合理的测例

### DIFF
--- a/scripts/busybox/busybox_cmd.txt
+++ b/scripts/busybox/busybox_cmd.txt
@@ -20,7 +20,7 @@ ps
 pwd
 free
 hwclock
-kill 10
+sh -c 'sleep 5' & ./busybox kill $!
 ls
 sleep 1
 echo "#### file opration test"


### PR DESCRIPTION
原测例kill 10的含义是kill掉pid=10的进程，但其实不能保证系统中一定存在pid=10的进程，因此这个测例不合理。
郑友捷学长提出了一个更加合理的测例，即`sh -c 'sleep 5' & ./busybox kill $!`，意思是创建一个进程在后台执行sleep操作，然后kill掉这个后台进程，这样更加合理。这个修改已经在训练营的评测中实验过，如果对kill实现正确是可以通过测试的。