### PR TITLE
在cJSON_New_Item中初始化钩子函数

### DIFF
--- a/iperf/src/cjson.c
+++ b/iperf/src/cjson.c
@@ -264,6 +264,7 @@ CJSON_PUBLIC(void) cJSON_InitHooks(cJSON_Hooks* hooks)
 /* Internal constructor. */
 static cJSON *cJSON_New_Item(const internal_hooks * const hooks)
 {
+    cJSON_InitHooks(NULL); 
     cJSON* node = (cJSON*)hooks->allocate(sizeof(cJSON));
     if (node)
     {


### PR DESCRIPTION
在为 starry-next 兼容 iperf 的过程中，我发现一个段错误问题。具体来说，如果在 cJSON_New_Item 函数中未对全局变量 global_hooks 进行初始化，会导致空指针访问。然而，当我单独编译 cJSON 的相关代码时，并未复现此异常。我推测这可能是由于编译为 ELF 文件时，编译器进行了某种优化所致。将 global_hooks 的初始化操作增加到 cJSON_New_Item 函数的起始位置后，该段错误便得以消除。