### PR TITLE
test(interrupts-test2): fix StorePageFault issue on LoongArch witth glibc toolchain

### DIFF
--- a/interrupts-test/test2.c
+++ b/interrupts-test/test2.c
@@ -64,6 +64,7 @@ void check() {
 }
 
 int main() {
+    puts("");
     check();
     usleep(100000);
     check();


### PR DESCRIPTION
When compiled with the glibc toolchain on the LoongArch64 platform, this test quickly crashed for StorePageFault when the libc initialization just finished and entered main. When checking the exception, the exception address points to a valid position in the brk area WITH write permission. I can not think of why because the musl toolchain and RISC-V platform runs perfectly.

This PR is a simple workaround with only one line of code but effectively fixed the issue, like magic. It add an unwanted new line in the beginning, but as long as it doesn't break the judge script's parsing rule(it doesn't, in my test, with the script in this repository), I won't look for a better solution.

This PR is tested in [this run](https://github.com/caiyih/bakaos/actions/runs/16498115358/job/46648918840) with sdcard image [here](https://github.com/neuq-rcore/testsuits-for-oskernel/releases/tag/final-2025)
