### PR TITLE
fix(buildstorm): 以正式 timed 构建耗时作为 Linux baseline

### DIFF
--- a/judge/judge_buildstorm-glibc.py
+++ b/judge/judge_buildstorm-glibc.py
@@ -24,10 +24,12 @@ import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
-# Per-arch reference baselines (seconds). For contestant self-check only; the
-# final score is produced by the platform judge, which may use different values.
+# Per-arch reference baselines (seconds), measured from the timed formal build
+# only; the untimed tg-xtask pre-build is excluded. For contestant self-check
+# only; the final score is produced by the platform judge, which may use
+# different values.
 # Override via judge/config.json: baseline.rv_s / baseline.la_s.
-BASELINES = {"riscv64": 4655.23, "loongarch64": 6223.0}
+BASELINES = {"riscv64": 1616.09, "loongarch64": 1985.21}
 try:
     with open(os.path.join(HERE, "config.json")) as f:
         cfg = json.load(f)


### PR DESCRIPTION
## 问题

`judge_buildstorm-glibc.py` 使用 `time_score(t, baseline)` 计算时间分，其中 `t` 是正式构建结果里的 `elapsed_s`。按照 README 和测试脚本的定义，计时窗口只覆盖：

```text
cargo xtask arceos build -p arceos-helloworld --arch ...
```

它不包含前面的 `pre-build tg-xtask (untimed)`，也不包含后面的启动验证 `(untimed)`。因此 Linux baseline 需要和被评分的 `elapsed_s` 使用相同计时窗口，不能使用包含 untimed 阶段的完整任务时长或任务超时时间。

当前 `BASELINES` 中的 `4655.23 / 6223.0` 与被评分窗口不一致。本 PR 用两份 Linux 实测日志中的正式构建 `elapsed_s` 校准它们。这两份日志是从选手侧提交评测后下载得到，应该更加适合作为评分基线。

## 实测结果

| 架构 | tg-xtask 预构建（untimed，不计分） | 正式构建（timed，用于评分） | baseline 修改 |
| --- | ---: | ---: | ---: |
| RISC-V64 | 58m 27s | `elapsed_s=1616.09` | `4655.23 -> 1616.09` |
| LoongArch64 | 64m 45s | `elapsed_s=1985.21` | `6223.0 -> 1985.21` |

RISC-V64 的实际边界：

```text
----- pre-build tg-xtask (untimed) -----
...
Finished `dev` profile [unoptimized + debuginfo] target(s) in 58m 27s
----- build arceos-helloworld (timed, arch=riscv64) -----
BUILDSTORM_BEGIN mode=multi
...
----- boot arceos-helloworld in qemu (untimed, arch=riscv64) -----
BUILDSTORM_RESULT mode=multi status=OK rc=0 cores=8 elapsed_s=1616.09 ... run=OK
```

LoongArch64 的实际边界：

```text
----- pre-build tg-xtask (untimed) -----
...
Finished `dev` profile [unoptimized + debuginfo] target(s) in 64m 45s
----- build arceos-helloworld (timed, arch=loongarch64) -----
BUILDSTORM_BEGIN mode=multi
...
----- boot arceos-helloworld in qemu (untimed, arch=loongarch64) -----
BUILDSTORM_RESULT mode=multi status=OK rc=0 cores=8 elapsed_s=1985.21 ... run=OK
```

平台基线日志使用 `BUILDSTORM_RESULT`，当前 contestant-facing 参考脚本使用 `BUILDSTORM_COMPILE`；这里取的是二者共同定义的正式构建 `elapsed_s` 计时窗口。本 PR 不改标记解析逻辑。

## 完整原始日志

两份完整日志放在同一个公开 Gist 中，可以逐行查看：

- [RISC-V64 Linux BuildStorm 完整日志](https://gist.github.com/Alayfolk64/16477fa783699ba14bc103b6b115de9d#file-riscv64-linux-buildstorm-baseline-txt)（38,862 bytes，SHA-256 `3b6da4eaa2979bdaffdc33ba6e7567194be5e9316d43a4e1bd969d2a4181d91f`）
- [LoongArch64 Linux BuildStorm 完整日志](https://gist.github.com/Alayfolk64/16477fa783699ba14bc103b6b115de9d#file-loongarch64-linux-buildstorm-baseline-txt)（38,864 bytes，SHA-256 `0e691e9351aabf8cfbbcbd3a3eaa2b12ddf5a593c63c9f424e8b3c12984fdda6`）

## 修改范围

只修改两个 per-arch baseline 常量和相邻注释。计分公式、结果解析、测试流程以及 `timeout 14400` 均未修改。

## 验证

- 将两个实测 `elapsed_s` 输入参考 judge，两个架构的时间分均为 `120.0`，脚本总分为 `180.0 / 180.0`
- `git diff --check`
- `sh -n scripts/buildstorm_testcode.sh`
- Python 源码编译检查
